### PR TITLE
Use underscore map instead of native

### DIFF
--- a/src/backbone/GoogleChart.coffee
+++ b/src/backbone/GoogleChart.coffee
@@ -18,7 +18,7 @@ class Backbone.GoogleChart extends Backbone.View
   ###
   initialize: ( options ) ->
     chartOptions = _.extend({},options)
-    ['el','id','attributes','className','tagName'].map (k) -> delete chartOptions[k]
+    _(['el','id','attributes','className','tagName']).map (k) -> delete chartOptions[k]
 
     google.load('visualization', '1', packages: ['corechart'], callback: => @onGoogleLoad "loaded")
 


### PR DESCRIPTION
IE7 doesn't support native map.

Trying to use this lovely library, and whilst checking in IE7 that there was a JS error.
Debugging exposed the native map function.

You're already using underscore, so wrap the array as an underscore array and happiness abounds.
